### PR TITLE
Don't use snapshot build for Microsoft.NETCore.App

### DIFF
--- a/hhs-p6-webshop-project/project.json
+++ b/hhs-p6-webshop-project/project.json
@@ -31,7 +31,7 @@
     "Microsoft.Extensions.Logging.Debug": "1.1.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
     "Microsoft.NETCore.App": {
-        "version": "1.1.0-*",
+        "version": "1.1.0",
         "type": "platform"
     },
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.1.0",


### PR DESCRIPTION
Don't use snapshot build for Microsoft.NETCore.App